### PR TITLE
fix: Add error type handling for anonymous type

### DIFF
--- a/src/JsonDataMasking.Test/JsonMaskTests.cs
+++ b/src/JsonDataMasking.Test/JsonMaskTests.cs
@@ -321,19 +321,6 @@ namespace JsonDataMasking.Test
         }
 
         [Fact]
-        public void MaskSensitiveData_DoesNotMask_WhenDataHasAnonymousType()
-        {
-            // Arrange
-            var anonymousObj = new { a = 123, b = "123"};
-
-            // Act
-            var maskedAnonymousObj = JsonMask.MaskSensitiveData(anonymousObj);
-
-            // Assert
-            Assert.Equal(anonymousObj.a, maskedAnonymousObj.a);
-        }
-
-        [Fact]
         public void MaskSensitiveData_MasksProperty_WhenDataHasAnonymousType()
         {
             // Arrange

--- a/src/JsonDataMasking.Test/JsonMaskTests.cs
+++ b/src/JsonDataMasking.Test/JsonMaskTests.cs
@@ -334,6 +334,24 @@ namespace JsonDataMasking.Test
         }
 
         [Fact]
+        public void MaskSensitiveData_MasksProperty_WhenDataHasAnonymousType()
+        {
+            // Arrange
+            var customer = new CustomerMock
+            {
+                FullName = "John Doe"
+            };
+            var anonymousObj = new { customer };
+            var expectedObj = new CustomerMock { FullName = "*****" };
+
+            // Act
+            var maskedAnonymousObj = JsonMask.MaskSensitiveData(anonymousObj);
+
+            // Assert
+            Assert.Equal(expectedObj.FullName, maskedAnonymousObj.customer.FullName);
+        }
+
+        [Fact]
         public void MaskSensitiveData_DoesNotEnterInfiniteLoop_WhenDataHasACycle()
         {
             // Arrange

--- a/src/JsonDataMasking/Masks/JsonMask.cs
+++ b/src/JsonDataMasking/Masks/JsonMask.cs
@@ -96,7 +96,13 @@ namespace JsonDataMasking.Masks
         private static void MaskClassProperty<T>(T data, PropertyInfo property)
         {
             var maskedNestedPropertyValue = MaskPropertiesWithSensitiveDataAttribute(property.GetValue(data));
-            property.SetValue(data, maskedNestedPropertyValue);
+            if (!IsPropertyTypeEqualsToAnonymousType(property))
+                property.SetValue(data, maskedNestedPropertyValue);
+        }
+
+        private static bool IsPropertyTypeEqualsToAnonymousType(PropertyInfo property)
+        {
+            return property.ReflectedType.AssemblyQualifiedName.Contains("AnonymousType");
         }
 
         private static void MaskIEnumerableProperty<T>(T data, PropertyInfo property)
@@ -109,7 +115,7 @@ namespace JsonDataMasking.Masks
             foreach (var value in collection)
             {
                 if (collectionType is null) collectionType = value.GetType();
-                
+
                 object? maskedCollectionValue = null;
                 if (IsClassReferenceType(collectionType))
                     maskedCollectionValue = MaskPropertiesWithSensitiveDataAttribute(value);

--- a/src/JsonDataMasking/Masks/JsonMask.cs
+++ b/src/JsonDataMasking/Masks/JsonMask.cs
@@ -100,11 +100,6 @@ namespace JsonDataMasking.Masks
                 property.SetValue(data, maskedNestedPropertyValue);
         }
 
-        private static bool IsPropertyTypeEqualsToAnonymousType(PropertyInfo property)
-        {
-            return property.ReflectedType.AssemblyQualifiedName.Contains("AnonymousType");
-        }
-
         private static void MaskIEnumerableProperty<T>(T data, PropertyInfo property)
         {
             var collection = (property.GetValue(data) as IEnumerable)!;
@@ -162,6 +157,9 @@ namespace JsonDataMasking.Masks
         #endregion Convertion
 
         #region Validations
+        private static bool IsPropertyTypeEqualsToAnonymousType(PropertyInfo property) =>
+            property.ReflectedType.AssemblyQualifiedName.Contains("AnonymousType");
+
         private static bool IsSupportedBaseType(Type type) => type switch
         {
             Type _ when type == typeof(string) => true,


### PR DESCRIPTION
fix: Add error type handling for anonymous type

A test to validate this case was also added. 

It solves the error `System.ArgumentException Message=Property set method not found.` when trying to mask an object like this: 
`var anonymousObj = new { customer };`